### PR TITLE
Add Ubuntu/Linux support to setup script

### DIFF
--- a/setup_custom_fortunes.sh
+++ b/setup_custom_fortunes.sh
@@ -1,24 +1,53 @@
 #!/bin/bash
+# Script to copy all custom fortunes and initialize them
+# Works on Ubuntu & macOS; may work on other Linux distributions
 
 LOCATION=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-HOST_FORTUNE_DIR="/usr/local/share/games/fortunes"
+FORTUNE_CHECK=$(command -v fortune)
+OS_CHECK=$(uname)
 
-# Check if fortune is installed, exit if it isn't installed
-# If fortune is installed:
-# - Symlink all files to the fortunes directory 
-# - Create the .dat files
-if command -v fortune;
+configure_custom_fortunes(){
+        # Make list of all files cloned from repository
+        ls custom_fortunes/ >> /tmp/fortunes_tmp
+        # Symlink all custom fortunes to the direcotry on the machine
+        ln -s ${LOCATION}/custom_fortunes/* ${HOST_FORTUNE_DAT_DIR}/
+        cd ${HOST_FORTUNE_DAT_DIR}
+        # Create .dat fortune files
+        for item in `cat /tmp/fortunes_tmp`;
+        do
+                strfile ${item}
+        done
+        # Delete list that we created
+        rm -f /tmp/fortunes_tmp
+}
+
+# Check if fortune binary is installed, exit if it isn't installed
+if ! [ "${FORTUNE_CHECK}" ];
 then
-    echo "Fortune is not installed."
-    echo "Please install fortune."
-    exit 1
+        echo "Fortune is not installed."
+        echo "Please install fortune."
+        exit 1
 else
-    ls custom_fortunes/ >> /tmp/fortunes_tmp
-    ln -s ${LOCATION}/custom_fortunes/* ${HOST_FORTUNE_DIR}/
-    cd ${HOST_FORTUNE_DIR}
-    for item in `cat /tmp/fortunes_tmp`;
-    do 
-        strfile ${item}
-    done
-    rm -f /tmp/fortunes_tmp
+        echo "Setting up custom fortunes..."
+fi
+
+# Check if machine is running macOS
+if [ ${OS_CHECK} == "Darwin" ];
+then
+        echo "Confirmed macOS, configuring fortunes..."
+        # Set location of fortune's .dat files on macOS hosts
+        HOST_FORTUNE_DAT_DIR="/usr/local/share/games/fortunes"
+        echo "Set fortunes .dat file directory to ${HOST_FORTUNE_DAT_DIR}..."
+        echo "Configuring custom fortunes..."
+        configure_custom_fortunes
+# Check is machine is running Debian/Ubuntu/Linux
+elif [ ${OS_CHECK}  == "Linux" ];
+then
+        echo "Confirmed Linux distribution, configuring fortunes"
+        echo ""
+        # Set location of fortune's .dat files on Debian/Ubuntu/Linux hosts
+        HOST_FORTUNE_DAT_DIR="/usr/share/games/fortunes"
+        echo "Set fortunes .dat file directory to ${HOST_FORTUNE_DAT_DIR}"
+        echo "Configuring custom fortunes..."
+        configure_custom_fortunes
 fi


### PR DESCRIPTION
Updated the script re: #17.  It should support both now without needing to adjust the directory location manually. Can you please check it out and also confirm (I pushed remote branch `setup_script` which you should be able to pull now.)

Updated the following:
- Added OS check using `uname`
- Separate out exit for lack of fortune installation
- Add comments and echo statements

Tested in a Docker container running Ubuntu 18.04 LTS and macOS 10.14.5